### PR TITLE
Cross Reference Badges in Helptext

### DIFF
--- a/index.html
+++ b/index.html
@@ -74,7 +74,10 @@
             </div>
         </div>
         <div id="techtree">
-            <div id="helptext"></div>
+            <div id="helptext">
+                <div id="helptext__content"></div>
+                <div id="helptext__x_ref"></div>
+              </div>
         </div>
     </div>
 </div>
@@ -159,7 +162,10 @@
             }
         }
 
+        // load the civs
         loadCiv();
+        // Make the xref badges
+        document.getElementById('helptext__x_ref').appendChild(createXRefBadges());
     });
 
     function imagePrefix(name) {
@@ -200,13 +206,18 @@
 
     function displayHelp(overlayId) {
         let helptext = document.getElementById("helptext");
+        let helptextContent = document.getElementById("helptext__content");
+        let helptextXRef = document.getElementById("helptext__x_ref");
         let overlay = SVG.get(overlayId);
         let name = overlay.data('name');
         let id = overlay.data('id');
         let caret = overlay.data('caret');
         let type = overlay.data('type');
         let content = getHelpText(name, id, type);
-        helptext.innerHTML = content;
+        helptextContent.innerHTML = content;
+
+        badgeXRef(name, type);
+
         helptext.style.display = "block";
 
         let top = caret.y + caret.height;
@@ -260,6 +271,138 @@
         }
         return text.substring(0, text.length - 1);
 
+    }
+
+    /**
+     * Create the Cross-Reference badges. This is done at load time in order to avoid re-making the
+     * badges at runtime per-click on a new unit.
+     * 
+     * @return A container with buttons + images for each civ to be used in cross referencing.
+     */
+     function createXRefBadges() {
+        let xRefLinks = document.createElement('div');
+        xRefLinks.id = "helptext__x_ref__container";
+
+        for (let civ of Object.keys(data.civs)) {
+            let xRefLink = document.createElement('button');
+            xRefLink.addEventListener('click', function() {
+              document.getElementById('civselect').value=civ;
+              loadCiv();
+            });
+
+            // Add a badge for this civ if this element isn't disabled, or if it is a unique unit and not enabled.
+            let xRefImage = document.createElement('img');
+
+            xRefImage.src = `./img/Civs/${civ.toLowerCase()}.png`;
+            xRefImage.title = `${civ}`;
+            xRefImage.id = `xRef__badge__${civ}`;
+            xRefLink.appendChild(xRefImage);
+            xRefLinks.appendChild(xRefLink);
+        }
+        return xRefLinks;
+    }
+
+    /** 
+     * Set on/off of all cross reference badges for a single unit.
+     * 
+     * @param {string} name The name of the entity being cross-reference. 
+     * @param {string} type The type of the entity being cross-reference.
+     */
+    function badgeXRef(name, type) {
+        for (let civ of Object.keys(data.civs)) {
+            let xRefImage = document.getElementById(`xRef__badge__${civ}`);
+            // By default, assume that this unit can be built.
+            let found = true;
+            // Get the config objects
+            let enabled = civsConfig[`${civ}`]['enabled'];
+            let disabled = civsConfig[`${civ}`]['disabled'];
+            let unique = civsConfig[`${civ}`]['unique'];
+
+            // Make sure this civ exists
+            if (civsConfig[`${civ}`]) {
+                // Fast-Fail horses if civ disablesHorses
+                if (civsConfig[`${civ}`]['disableHorses'] &&
+                    horseDisabled.includes(name)) {
+                    found = false;
+                }
+                if (type === "UNIT") {
+                    // There are 2 ways for a UNIT to be disabled.
+                    //      1. The unit is disabled by default, and not 
+                    //         specifically enabled in the config.
+                    //      2. The unit is disabled in the specific config.
+
+                    // if this unit is disabled by default, and
+                    if (defaultDisabled.includes(name) &&
+                        // if there is no enabled object or
+                        (!enabled ||
+                         // if there are no enabled units or
+                         !enabled['units'] ||
+                         // if the unit is not specifically enabled
+                         !enabled['units'].includes(name))) {
+                        found = false;
+                    // if there is a disabled object and
+                    } else if (disabled &&
+                            // if there are disabled units and
+                            disabled['units'] &&
+                            // if this unit is specifically disabled
+                            disabled['units'].includes(name)) {
+                        found = false;
+                    }
+                } else if (type === "UNIQUEUNIT") {
+                    // There are 2 ways for a UNIQUEUNIT to be disabled.
+                    //      1. The UNIQUEUNIT can be enabled in 'unique'.
+                    //      2. The UNIQUEUNIT can be enabled in 'unit'.
+                    //          e.g. genitour
+                
+                    // if there is not a unique object or
+                    if ((!unique ||
+                         // if the unit is not in the unique object
+                         !unique.includes(name)) &&
+                        // if there is not an enabled or if there is not a units object or
+                        (!enabled || !enabled['units'] ||
+                         // if the unit is not in the enabled object
+                         !enabled['units'].includes(name))) {
+                        found = false;    
+                    }
+                } else if (type === "TECHNOLOGY") {
+                    // Technology is only ever disabled. See js/techtree.js#resetToDefault
+                    // if there is a tech object in disabled, and this tech is in it
+                    if (disabled['techs'] && disabled['techs'].includes(name)) {
+                        found = false;
+                    }
+                }
+                else if (type === "BUILDING") {
+                    // There are 2 ways for a BUILDING to be disabled.
+                    //      1. The building is disabled by default, and not 
+                    //         specifically enabled in the config.
+                    //      2. The building is disabled in the specific config.
+
+                    // if this building is disabled by default, and
+                    if (defaultDisabledBuildings.includes(name) &&
+                    // if there is no enabled object or
+                    (!enabled ||
+                    // if there are no enabled buildings or 
+                    !enabled['buildings'] ||
+                    // if the building is not specifically enabled
+                    !enabled['buildings'].includes(name))) {
+                        found = false;
+                    // if there is a disabled object and
+                    } else if (disabled &&
+                            // if there are disabled buildings and
+                            disabled['buildings'] &&
+                            // if the building is specifically disabled
+                            disabled['buildings'].includes(name)
+                            ) {
+                        found = false;
+                    }
+                }
+            }
+            if (found) {
+                xRefImage.style.opacity = '100%';
+            } else {
+                xRefImage.style.opacity = '20%';
+            }
+        }
     }
 
     function ifDefined(value, prefix) {

--- a/index.html
+++ b/index.html
@@ -307,6 +307,7 @@
      * @param {string} type The type of the entity being cross-referenced.
      */
     function styleXRefBadges(name, type) {
+        let horseDisabledAll = horseDisabledBuildings.concat(horseDisabledUnits).concat(horseDisabledTechs);
         for (let civ of Object.keys(data.civs)) {
             let xRefImage = document.getElementById(`xRef__badge__${civ}`);
             // By default, assume that this unit can be built.
@@ -320,7 +321,7 @@
             if (civsConfig[`${civ}`]) {
                 // Fast-Fail horses if civ disablesHorses
                 if (civsConfig[`${civ}`]['disableHorses'] &&
-                    horseDisabledBuildings.concat(horseDisabledUnits).concat(horseDisabledTech).includes(name)) {
+                    horseDisabledAll.includes(name)) {
                     found = false;
                 }
                 if (type === "UNIT") {

--- a/index.html
+++ b/index.html
@@ -320,7 +320,7 @@
             if (civsConfig[`${civ}`]) {
                 // Fast-Fail horses if civ disablesHorses
                 if (civsConfig[`${civ}`]['disableHorses'] &&
-                    horseDisabled.includes(name)) {
+                    horseDisabledBuildings.concat(horseDisabledUnits).concat(horseDisabledTech).includes(name)) {
                     found = false;
                 }
                 if (type === "UNIT") {

--- a/index.html
+++ b/index.html
@@ -162,7 +162,6 @@
             }
         }
 
-        // load the civs
         loadCiv();
         // Make the xref badges
         document.getElementById('helptext__x_ref').appendChild(createXRefBadges());
@@ -216,7 +215,7 @@
         let content = getHelpText(name, id, type);
         helptextContent.innerHTML = content;
 
-        badgeXRef(name, type);
+        styleXRefBadges(name, type);
 
         helptext.style.display = "block";
 
@@ -290,7 +289,6 @@
               loadCiv();
             });
 
-            // Add a badge for this civ if this element isn't disabled, or if it is a unique unit and not enabled.
             let xRefImage = document.createElement('img');
 
             xRefImage.src = `./img/Civs/${civ.toLowerCase()}.png`;
@@ -308,7 +306,7 @@
      * @param {string} name The name of the entity being cross-reference. 
      * @param {string} type The type of the entity being cross-reference.
      */
-    function badgeXRef(name, type) {
+    function styleXRefBadges(name, type) {
         for (let civ of Object.keys(data.civs)) {
             let xRefImage = document.getElementById(`xRef__badge__${civ}`);
             // By default, assume that this unit can be built.
@@ -330,21 +328,13 @@
                     //      1. The unit is disabled by default, and not 
                     //         specifically enabled in the config.
                     //      2. The unit is disabled in the specific config.
-
-                    // if this unit is disabled by default, and
-                    if (defaultDisabled.includes(name) &&
-                        // if there is no enabled object or
+                    if (defaultDisabledUnits.includes(name) &&
                         (!enabled ||
-                         // if there are no enabled units or
                          !enabled['units'] ||
-                         // if the unit is not specifically enabled
                          !enabled['units'].includes(name))) {
                         found = false;
-                    // if there is a disabled object and
                     } else if (disabled &&
-                            // if there are disabled units and
                             disabled['units'] &&
-                            // if this unit is specifically disabled
                             disabled['units'].includes(name)) {
                         found = false;
                     }
@@ -353,14 +343,9 @@
                     //      1. The UNIQUEUNIT can be enabled in 'unique'.
                     //      2. The UNIQUEUNIT can be enabled in 'unit'.
                     //          e.g. genitour
-                
-                    // if there is not a unique object or
                     if ((!unique ||
-                         // if the unit is not in the unique object
                          !unique.includes(name)) &&
-                        // if there is not an enabled or if there is not a units object or
                         (!enabled || !enabled['units'] ||
-                         // if the unit is not in the enabled object
                          !enabled['units'].includes(name))) {
                         found = false;    
                     }
@@ -376,23 +361,14 @@
                     //      1. The building is disabled by default, and not 
                     //         specifically enabled in the config.
                     //      2. The building is disabled in the specific config.
-
-                    // if this building is disabled by default, and
                     if (defaultDisabledBuildings.includes(name) &&
-                    // if there is no enabled object or
                     (!enabled ||
-                    // if there are no enabled buildings or 
                     !enabled['buildings'] ||
-                    // if the building is not specifically enabled
                     !enabled['buildings'].includes(name))) {
                         found = false;
-                    // if there is a disabled object and
                     } else if (disabled &&
-                            // if there are disabled buildings and
-                            disabled['buildings'] &&
-                            // if the building is specifically disabled
-                            disabled['buildings'].includes(name)
-                            ) {
+                               disabled['buildings'] &&
+                               disabled['buildings'].includes(name)) {
                         found = false;
                     }
                 }

--- a/js/civs.js
+++ b/js/civs.js
@@ -7,7 +7,7 @@ function civ(name, tree) {
     let disabled = selectedCiv.disabled || {};
     let uniqueConfig = selectedCiv.unique || {};
     if (selectedCiv.disableHorses) {
-        disableHorses(tree);
+        disableHorses();
     }
 
     enable(enabled.buildings || [], enabled.units || [], enabled.techs || []);
@@ -25,7 +25,6 @@ const civsConfig = {
           ],
           techs: [ 
              THUMB_RING,
-             PARTHIAN_TACTICS,
              HOARDINGS,
              RING_ARCHER_ARMOR,
              MASONRY,

--- a/js/techtree.js
+++ b/js/techtree.js
@@ -337,6 +337,17 @@ const ELITE_BERSERK = "Elite Berserk";
 const CHIEFTAINS = "Chieftains";
 const BERSERKERGANG = "Berserkergang";
 
+const horseDisabled = [STABLE, 
+    SCOUT_CAVALRY, LIGHT_CAVALRY, HUSSAR,
+    BLOODLINES, KNIGHT, CAVALIER, PALADIN,
+    CAMEL_RIDER, HEAVY_CAMEL_RIDER, HUSBANDRY,
+    CAVALRY_ARCHER, HEAVY_CAV_ARCHER, SCALE_BARDING_ARMOR,
+    CHAIN_BARDING_ARMOR, PLATE_BARDING_ARMOR, PARTHIAN_TACTICS];
+
+const defaultDisabled = [EAGLE_SCOUT, EAGLE_WARRIOR, ELITE_EAGLE_WARRIOR, BATTLE_ELEPHANT,
+    ELITE_BATTLE_ELEPHANT, STEPPE_LANCER, ELITE_STEPPE_LANCER,];
+    
+const defaultDisabledBuildings = [KREPOST, FEITORIA,];
 
 class Tree {
     constructor() {
@@ -532,10 +543,8 @@ function resetToDefault(tree) {
     SVG.select('.cross').animate(animation_duration).attr({'fill-opacity': 0});
     disableUniqueUnits(tree);
     enable([], [UNIQUE_UNIT, ELITE_UNIQUE_UNIT], []);
-    disable([], [EAGLE_SCOUT, EAGLE_WARRIOR, ELITE_EAGLE_WARRIOR], []);
-    disable([], [BATTLE_ELEPHANT, ELITE_BATTLE_ELEPHANT], []);
-    disable([], [STEPPE_LANCER, ELITE_STEPPE_LANCER], []);
-    disable([KREPOST, FEITORIA], [], []);
+    disable([], defaultDisabled, []);
+    disable(defaultDisabledBuildings, [], []);
 }
 
 function disable(buildings, units, techs) {

--- a/js/techtree.js
+++ b/js/techtree.js
@@ -340,7 +340,7 @@ const BERSERKERGANG = "Berserkergang";
 const horseDisabledBuildings = [STABLE];
 const horseDisabledUnits = [SCOUT_CAVALRY, LIGHT_CAVALRY, HUSSAR, KNIGHT, PALADIN, CAMEL_RIDER,
     HEAVY_CAMEL_RIDER, CAVALIER, CAVALRY_ARCHER, HEAVY_CAV_ARCHER];
-const horseDisabledTech = [BLOODLINES, HUSBANDRY, SCALE_BARDING_ARMOR, CHAIN_BARDING_ARMOR,
+const horseDisabledTechs = [BLOODLINES, HUSBANDRY, SCALE_BARDING_ARMOR, CHAIN_BARDING_ARMOR,
     PLATE_BARDING_ARMOR, PARTHIAN_TACTICS];
 
 const defaultDisabledUnits = [EAGLE_SCOUT, EAGLE_WARRIOR, ELITE_EAGLE_WARRIOR, BATTLE_ELEPHANT,
@@ -615,7 +615,7 @@ function unique(names, monk_prefix) {
 
 
 function disableHorses() {
-    disable(horseDisabledBuildings, horseDisabledUnits, horseDisabledTech);
+    disable(horseDisabledBuildings, horseDisabledUnits, horseDisabledTechs);
 }
 
 

--- a/js/techtree.js
+++ b/js/techtree.js
@@ -344,7 +344,7 @@ const horseDisabled = [STABLE,
     CAVALRY_ARCHER, HEAVY_CAV_ARCHER, SCALE_BARDING_ARMOR,
     CHAIN_BARDING_ARMOR, PLATE_BARDING_ARMOR, PARTHIAN_TACTICS];
 
-const defaultDisabled = [EAGLE_SCOUT, EAGLE_WARRIOR, ELITE_EAGLE_WARRIOR, BATTLE_ELEPHANT,
+const defaultDisabledUnits = [EAGLE_SCOUT, EAGLE_WARRIOR, ELITE_EAGLE_WARRIOR, BATTLE_ELEPHANT,
     ELITE_BATTLE_ELEPHANT, STEPPE_LANCER, ELITE_STEPPE_LANCER,];
     
 const defaultDisabledBuildings = [KREPOST, FEITORIA,];
@@ -543,8 +543,7 @@ function resetToDefault(tree) {
     SVG.select('.cross').animate(animation_duration).attr({'fill-opacity': 0});
     disableUniqueUnits(tree);
     enable([], [UNIQUE_UNIT, ELITE_UNIQUE_UNIT], []);
-    disable([], defaultDisabled, []);
-    disable(defaultDisabledBuildings, [], []);
+    disable(defaultDisabledBuildings, defaultDisabledUnits, []);
 }
 
 function disable(buildings, units, techs) {

--- a/js/techtree.js
+++ b/js/techtree.js
@@ -337,12 +337,11 @@ const ELITE_BERSERK = "Elite Berserk";
 const CHIEFTAINS = "Chieftains";
 const BERSERKERGANG = "Berserkergang";
 
-const horseDisabled = [STABLE, 
-    SCOUT_CAVALRY, LIGHT_CAVALRY, HUSSAR,
-    BLOODLINES, KNIGHT, CAVALIER, PALADIN,
-    CAMEL_RIDER, HEAVY_CAMEL_RIDER, HUSBANDRY,
-    CAVALRY_ARCHER, HEAVY_CAV_ARCHER, SCALE_BARDING_ARMOR,
-    CHAIN_BARDING_ARMOR, PLATE_BARDING_ARMOR, PARTHIAN_TACTICS];
+const horseDisabledBuildings = [STABLE];
+const horseDisabledUnits = [SCOUT_CAVALRY, LIGHT_CAVALRY, HUSSAR, KNIGHT, PALADIN, CAMEL_RIDER,
+    HEAVY_CAMEL_RIDER, CAVALIER, CAVALRY_ARCHER, HEAVY_CAV_ARCHER];
+const horseDisabledTech = [BLOODLINES, HUSBANDRY, SCALE_BARDING_ARMOR, CHAIN_BARDING_ARMOR,
+    PLATE_BARDING_ARMOR, PARTHIAN_TACTICS];
 
 const defaultDisabledUnits = [EAGLE_SCOUT, EAGLE_WARRIOR, ELITE_EAGLE_WARRIOR, BATTLE_ELEPHANT,
     ELITE_BATTLE_ELEPHANT, STEPPE_LANCER, ELITE_STEPPE_LANCER,];
@@ -615,25 +614,8 @@ function unique(names, monk_prefix) {
 }
 
 
-function disableHorses(tree) {
-    let stable_index = -1;
-    for (let i = 0; i < tree.lanes.length; i++) {
-        let lane = tree.lanes[i];
-        for (let r of Object.keys(lane.rows)) {
-            for (let caret of lane.rows[r]) {
-                if (caret.id === 'building_' + formatId(STABLE)) {
-                    stable_index = i;
-                }
-            }
-        }
-    }
-    let lane = tree.lanes[stable_index];
-    for (let r of Object.keys(lane.rows)) {
-        for (let caret of lane.rows[r]) {
-            SVG.get(caret.id + '_x').animate(animation_duration).attr({'fill-opacity': 1});
-        }
-    }
-    disable([], [CAVALRY_ARCHER, HEAVY_CAV_ARCHER], [SCALE_BARDING_ARMOR, CHAIN_BARDING_ARMOR, PLATE_BARDING_ARMOR, PARTHIAN_TACTICS]);
+function disableHorses() {
+    disable(horseDisabledBuildings, horseDisabledUnits, horseDisabledTech);
 }
 
 

--- a/style.css
+++ b/style.css
@@ -3,6 +3,7 @@
             width: 100%;
             height: 100%;
             box-sizing: border-box;
+            --xRef-badge-size: 30px;
         }
 
         body {
@@ -38,6 +39,26 @@
             border: 2px solid #bbb;
             padding: 0.2rem;
             font-size: 10pt;
+        }
+
+        #helptext__x_ref__container {
+            /* There are 35 civs, 5x7 makes the badges into a nice square. */
+            max-width: calc(var(--xRef-badge-size) * 7);
+            margin: auto;
+            padding-top: 0.2rem;
+        }
+
+        /* Style for helptext Cross-Reference buttons */
+        #helptext #helptext__x_ref div button {
+            background-color: transparent;
+            border: none;
+            padding: 0;
+        }
+
+        /* Style for helptext Cross-Reference image badges */
+        #helptext #helptext__x_ref div button img {
+            width: var(--xRef-badge-size);
+            height: var(--xRef-badge-size);
         }
 
         #wrapper {


### PR DESCRIPTION
This adds a cross reference badging system to the helptext popups. This allows for easily checking what civs can build a unit, and to switch between civs based on that info.
Feature [staged on my fork](https://exterkamp.github.io/aoe2techtree/#Aztecs).
![image](https://user-images.githubusercontent.com/6392995/74306857-a0c46200-4d18-11ea-8a22-e79dc649bbb0.png)



