### PR TITLE
Lock Civ Metadata to Left

### DIFF
--- a/index.html
+++ b/index.html
@@ -262,10 +262,9 @@
 
         let helpbox = helptext.getBoundingClientRect();
         let tt = document.getElementById('techtree');
-        // If the X would be less than 0, or offscreen due to scrolling,
-        // set the helptext to the right instead of left.
+        // If the X would be less than 0 put the helptext all the way to the left.
         if (destX < 0 || destX - tt.scrollLeft < 0) {
-            destX = caret.x + caret.width;
+            destX = tt.scrollLeft;
         }
         helptext.style.left = destX + 'px';
         resetHighlightPath();

--- a/index.html
+++ b/index.html
@@ -258,12 +258,16 @@
         }
         helptext.style.top = top + "px";
 
-        helptext.style.left = Math.max(0, (caret.x - helptext.offsetWidth)) + "px";
-        let helpbox = helptext.getBoundingClientRect();
-        if (helpbox.left < 0) {
-            helptext.style.left = Math.max(0, (caret.x - helptext.offsetWidth)) - helpbox.left + "px";
-        }
+        let destX = caret.x - helptext.offsetWidth;
 
+        let helpbox = helptext.getBoundingClientRect();
+        let tt = document.getElementById('techtree');
+        // If the X would be less than 0, or offscreen due to scrolling,
+        // set the helptext to the right instead of left.
+        if (destX < 0 || destX - tt.scrollLeft < 0) {
+            destX = caret.x + caret.width;
+        }
+        helptext.style.left = destX + 'px';
         resetHighlightPath();
     }
 

--- a/style.css
+++ b/style.css
@@ -176,5 +176,6 @@
         @media (max-width: 900px) {
             #techtree {
                 width: auto;
+                overflow-x: auto;
             }
         }

--- a/style.css
+++ b/style.css
@@ -34,7 +34,7 @@
         #helptext {
             position: absolute;
             display: none;
-            max-width: 300px;
+            width: 300px;
             background-color: #eee;
             border: 2px solid #bbb;
             padding: 0.2rem;
@@ -73,14 +73,19 @@
             background-color: #e7c28e;
         }
 
+
+
         #techtree {
-            border: 5px solid #4d3617;
+            border: 6px solid #4d3617;
             flex: 1 0 auto;
             position: relative;
+            width: calc(100vw - 22rem - 20px);
+            overflow-x: scroll;
         }
 
         #metainfo {
-            border: 5px solid #4d3617;
+            border: 6px solid #4d3617;
+            border-right: none;
             width: 20rem;
             flex: 0 0 auto;
             display: flex;
@@ -166,4 +171,10 @@
         .connection.is-highlight {
             stroke: #fff;
             stroke-width: 3px;
+        }
+
+        @media (max-width: 900px) {
+            #techtree {
+                width: auto;
+            }
         }


### PR DESCRIPTION
This locks the civilization summary screen to the left. Also this updates how the helptext is laid out, so that it is always locked to a corner of the caret icon.
![image](https://user-images.githubusercontent.com/6392995/75005728-24bad000-5424-11ea-8a6e-2a093096cb23.png)


On small screens the locked 300px size is excessive, so it reverts back to the legacy scroll when less than 900px.

[Hosted here.](https://exterkamp.github.io/aoe2techtree)

...as mentioned in #5 

Also small nit, this changes the borders to `6px` to match the horizontal borders between ages in the SVG.