### PR TITLE
Move Civ Select to Locked Left Nav

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,43 +12,6 @@
 <body>
 <div id="container">
     <div id="navigation">
-        <select id="civselect" onchange="loadCiv()">
-            <option>Aztecs</option>
-            <option>Berbers</option>
-            <option>Britons</option>
-            <option>Bulgarians</option>
-            <option>Burmese</option>
-            <option>Byzantines</option>
-            <option>Celts</option>
-            <option>Chinese</option>
-            <option>Cumans</option>
-            <option>Ethiopians</option>
-            <option>Franks</option>
-            <option>Goths</option>
-            <option>Huns</option>
-            <option>Incas</option>
-            <option>Indians</option>
-            <option>Italians</option>
-            <option>Japanese</option>
-            <option>Khmer</option>
-            <option>Koreans</option>
-            <option>Lithuanians</option>
-            <option>Magyars</option>
-            <option>Malay</option>
-            <option>Malians</option>
-            <option>Mayans</option>
-            <option>Mongols</option>
-            <option>Persians</option>
-            <option>Portuguese</option>
-            <option>Saracens</option>
-            <option>Slavs</option>
-            <option>Spanish</option>
-            <option>Tatars</option>
-            <option>Teutons</option>
-            <option>Turks</option>
-            <option>Vietnamese</option>
-            <option>Vikings</option>
-        </select>
         <div id="info">Version: Age of Empires II DE Update <a href="https://www.ageofempires.com/news/aoe2de-update-35584/" target="_blank" title="Changelog">35584</a>  |
             <a href="https://github.com/SiegeEngineers/aoe2techtree" target="_blank">GitHub</a>
         </div>
@@ -57,8 +20,45 @@
         <div id="metainfo">
             <div id="civinfo">
                 <div id="civtitle">
-                    <h2 id="civname">Loading…</h2>
+                    <select id="civselect" onchange="loadCiv()">
+                        <option>Aztecs</option>
+                        <option>Berbers</option>
+                        <option>Britons</option>
+                        <option>Bulgarians</option>
+                        <option>Burmese</option>
+                        <option>Byzantines</option>
+                        <option>Celts</option>
+                        <option>Chinese</option>
+                        <option>Cumans</option>
+                        <option>Ethiopians</option>
+                        <option>Franks</option>
+                        <option>Goths</option>
+                        <option>Huns</option>
+                        <option>Incas</option>
+                        <option>Indians</option>
+                        <option>Italians</option>
+                        <option>Japanese</option>
+                        <option>Khmer</option>
+                        <option>Koreans</option>
+                        <option>Lithuanians</option>
+                        <option>Magyars</option>
+                        <option>Malay</option>
+                        <option>Malians</option>
+                        <option>Mayans</option>
+                        <option>Mongols</option>
+                        <option>Persians</option>
+                        <option>Portuguese</option>
+                        <option>Saracens</option>
+                        <option>Slavs</option>
+                        <option>Spanish</option>
+                        <option>Tatars</option>
+                        <option>Teutons</option>
+                        <option>Turks</option>
+                        <option>Vietnamese</option>
+                        <option>Vikings</option>
+                    </select>
                     <img id="civlogo" height=52 width=52 data-transparent="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII=">
+
                 </div>
                 <hr>
                 <p id="civtext"></p>
@@ -178,7 +178,6 @@
     function loadCiv() {
         var selectedCiv = document.getElementById('civselect').value;
         civ(selectedCiv, tree);
-        document.getElementById('civname').innerText = selectedCiv;
         if (selectedCiv in data.civs) {
             document.getElementById('civtext').innerHTML = data.key_value[data.civs[selectedCiv]];
             document.getElementById('civlogo').src = `./img/Civs/${selectedCiv.toLowerCase()}.png`;

--- a/index.html
+++ b/index.html
@@ -65,8 +65,8 @@
                     Contribute on <a href="https://github.com/SiegeEngineers/aoe2techtree" target="_blank">GitHub</a>
                 </div>
                 <div>
-                    Made by hszemi, Anda, exterkamp, paulirish,</br>
-                    with thanks to Jineapple, TriRem, pip, and NkoDragaš</br>
+                    Made by hszemi, Anda, exterkamp, paulirish,<br>
+                    with thanks to Jineapple, TriRem, pip, and NkoDragaš<br>
                     Item Metadata (cost, HP etc.) taken from <a href="https://github.com/HSZemi/aoe2dat" target="_blank">aoe2dat</a>
                 </div>
             </div>

--- a/index.html
+++ b/index.html
@@ -57,22 +57,24 @@
                 <hr>
                 <p id="civtext"></p>
             </div>
-            <div id="version">
-                <div id="info">Version: Age of Empires II DE Update <a href="https://www.ageofempires.com/news/aoe2de-update-35584/" target="_blank" title="Changelog">35584</a>
-                    <br/>
-                    <a href="https://github.com/SiegeEngineers/aoe2techtree" target="_blank">GitHub</a>
-                </div>
+            <div id="version" class="info">
+                Version: Age of Empires II DE Update <a href="https://www.ageofempires.com/news/aoe2de-update-35584/" target="_blank" title="Changelog">35584</a>
             </div>
             <br/>
-            <div id="thanks">
-                <a href="https://github.com/SiegeEngineers/aoe2techtree" target="_blank">Made by</a> hszemi, Anda,
-                    exterkamp, paulirish,<br>
-                with huge thanks to Jineapple, TriRem, pip, and NkoDragaš
-                <!-- <br> Descriptions taken from the
-                <a href="https://www.voobly.com/gamemods/mod/650/Max-Extended-Help-AK" target="_blank">Max-Extended-Help-WK
-                    mod</a> -->
-                <br> Item Metadata (cost, HP etc.) taken from
-                <a href="https://github.com/HSZemi/aoe2dat" target="_blank">aoe2dat</a>
+            <div id="github" class="info">
+                Contribute on <a href="https://github.com/SiegeEngineers/aoe2techtree" target="_blank">GitHub</a>
+            </div>
+            <br/>
+            <div id="thanks" class="small_info">
+                <div>
+                    Made by hszemi, Anda, exterkamp, paulirish,
+                </div>
+                <div>
+                    with thanks to Jineapple, TriRem, pip, and NkoDragaš
+                </div>
+                <div>
+                    Item Metadata (cost, HP etc.) taken from <a href="https://github.com/HSZemi/aoe2dat" target="_blank">aoe2dat</a>
+                </div>
             </div>
         </div>
         <div id="techtree">

--- a/index.html
+++ b/index.html
@@ -11,11 +11,6 @@
 
 <body>
 <div id="container">
-    <div id="navigation">
-        <div id="info">Version: Age of Empires II DE Update <a href="https://www.ageofempires.com/news/aoe2de-update-35584/" target="_blank" title="Changelog">35584</a>  |
-            <a href="https://github.com/SiegeEngineers/aoe2techtree" target="_blank">GitHub</a>
-        </div>
-    </div>
     <div id="wrapper">
         <div id="metainfo">
             <div id="civinfo">
@@ -62,6 +57,13 @@
                 <hr>
                 <p id="civtext"></p>
             </div>
+            <div id="version">
+                <div id="info">Version: Age of Empires II DE Update <a href="https://www.ageofempires.com/news/aoe2de-update-35584/" target="_blank" title="Changelog">35584</a>
+                    <br/>
+                    <a href="https://github.com/SiegeEngineers/aoe2techtree" target="_blank">GitHub</a>
+                </div>
+            </div>
+            <br/>
             <div id="thanks">
                 <a href="https://github.com/SiegeEngineers/aoe2techtree" target="_blank">Made by</a> hszemi, Anda,
                     exterkamp, paulirish,<br>

--- a/index.html
+++ b/index.html
@@ -57,22 +57,16 @@
                 <hr>
                 <p id="civtext"></p>
             </div>
-            <div id="version" class="info">
-                Version: Age of Empires II DE Update <a href="https://www.ageofempires.com/news/aoe2de-update-35584/" target="_blank" title="Changelog">35584</a>
-            </div>
-            <br/>
-            <div id="github" class="info">
-                Contribute on <a href="https://github.com/SiegeEngineers/aoe2techtree" target="_blank">GitHub</a>
-            </div>
-            <br/>
-            <div id="thanks" class="small_info">
+            <div class="info">
                 <div>
-                    Made by hszemi, Anda, exterkamp, paulirish,
+                    Version: Age of Empires II DE Update <a href="https://www.ageofempires.com/news/aoe2de-update-35584/" target="_blank" title="Changelog">35584</a>
                 </div>
                 <div>
-                    with thanks to Jineapple, TriRem, pip, and NkoDragaš
+                    Contribute on <a href="https://github.com/SiegeEngineers/aoe2techtree" target="_blank">GitHub</a>
                 </div>
                 <div>
+                    Made by hszemi, Anda, exterkamp, paulirish,</br>
+                    with thanks to Jineapple, TriRem, pip, and NkoDragaš</br>
                     Item Metadata (cost, HP etc.) taken from <a href="https://github.com/HSZemi/aoe2dat" target="_blank">aoe2dat</a>
                 </div>
             </div>

--- a/index.html
+++ b/index.html
@@ -58,7 +58,6 @@
                         <option>Vikings</option>
                     </select>
                     <img id="civlogo" height=52 width=52 data-transparent="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII=">
-
                 </div>
                 <hr>
                 <p id="civtext"></p>

--- a/index.html
+++ b/index.html
@@ -58,10 +58,10 @@
                 <p id="civtext"></p>
             </div>
             <div class="info">
-                <div>
+                <div class="info__margin">
                     Version: Age of Empires II DE Update <a href="https://www.ageofempires.com/news/aoe2de-update-35584/" target="_blank" title="Changelog">35584</a>
                 </div>
-                <div>
+                <div class="info__margin">
                     Contribute on <a href="https://github.com/SiegeEngineers/aoe2techtree" target="_blank">GitHub</a>
                 </div>
                 <div>

--- a/style.css
+++ b/style.css
@@ -13,8 +13,8 @@
             align-items: center;
         }
 
-        #info,
-        #info a {
+        .info,
+        .info a {
             display: inline;
             font-family: monospace;
             color: gray;
@@ -108,8 +108,7 @@
         }
 
         #civselect option {
-            color: black;
-            background-color: white;
+            text-shadow: none;
         }
 
         #civselect:focus {
@@ -160,9 +159,9 @@
             margin-bottom: 0.5rem;
         }
 
-        #thanks,
-        #thanks a {
-            font-size: 6pt;
+        .small_info,
+        .small_info a {
+            font-size: 8pt;
             font-family: monospace;
             color: gray;
         }

--- a/style.css
+++ b/style.css
@@ -98,10 +98,22 @@
             font-size: 24px;
             font-weight: bold;
             font-family: 'Times New Roman', Times, serif;
-            background-color: transparent;
+            background-color: #72604a;
             flex: 1 0 auto;
             margin-right: 1rem;
-            border-color:  #a9885b;
+            color: white;
+            text-shadow: #000000 -3px 2px;
+            box-shadow: inset 0 2px #3f4806, inset 2px -2px #768141, inset -2px 0 #768141;
+            padding: 5px;
+        }
+
+        #civselect option {
+            color: black;
+            background-color: white;
+        }
+
+        #civselect:focus {
+            outline: none;
         }
 
         #civinfo {

--- a/style.css
+++ b/style.css
@@ -94,6 +94,16 @@
             padding: 1rem;
         }
 
+        #civselect {
+            font-size: 24px;
+            font-weight: bold;
+            font-family: 'Times New Roman', Times, serif;
+            background-color: transparent;
+            flex: 1 0 auto;
+            margin-right: 1rem;
+            border-color:  #a9885b;
+        }
+
         #civinfo {
             flex: 1 0 auto;
             font-size: 11pt;
@@ -104,16 +114,11 @@
             display: flex;
             justify-content: space-between;
             align-items: center;
+            padding: 0 1rem;
         }
 
         #thanks {
             flex: 0 0 auto;
-        }
-
-        #civname {
-            text-align: center;
-            flex: 1 0 auto;
-            margin: 0;
         }
 
         hr {

--- a/style.css
+++ b/style.css
@@ -21,7 +21,7 @@
             color: gray;
         }
 
-        .info div {
+        .info .info__margin {
             margin-bottom: 1rem;
         }
 

--- a/style.css
+++ b/style.css
@@ -15,9 +15,14 @@
 
         .info,
         .info a {
+            font-size: 8pt;
             display: inline;
             font-family: monospace;
             color: gray;
+        }
+
+        .info div {
+            margin-bottom: 1rem;
         }
 
         #container {
@@ -157,13 +162,6 @@
         #navigation {
             margin-top: 0.5rem;
             margin-bottom: 0.5rem;
-        }
-
-        .small_info,
-        .small_info a {
-            font-size: 8pt;
-            font-family: monospace;
-            color: gray;
         }
 
         .node__overlay {


### PR DESCRIPTION
Move the civ select to the locked left nav. Replaces the `civname` element.
![image](https://user-images.githubusercontent.com/6392995/75621832-76630900-5b4e-11ea-91b1-21b6de2c655a.png)

[Staged here](https://exterkamp.github.io/aoe2techtree/#Aztecs)

fixes: #5 