### PR TITLE
Add "compare unit" dropdown

### DIFF
--- a/index.html
+++ b/index.html
@@ -75,7 +75,10 @@
             <div id="helptext">
                 <div id="helptext__content"></div>
                 <div id="helptext__x_ref"></div>
-              </div>
+            </div>
+            <div id="comparetext">
+                <div id="comparetext__content"></div>
+            </div>
         </div>
     </div>
 </div>
@@ -273,6 +276,28 @@
         }
     }
 
+    function displayComparedUnit(dropdown) {
+        let name = dropdown.value;
+        let comparetext = document.getElementById("comparetext");
+        let comparetextContent = document.getElementById("comparetext__content");
+        if (name == '') {
+            comparetextContent.innerHTML = '';
+            comparetext.style.display = "none";
+            return;
+        }
+
+        let content = getHelpText(name, undefined, 'UNIT');
+
+        comparetextContent.innerHTML = content;
+
+        comparetext.style.display = "block";
+
+        let helptext = document.getElementById("helptext");
+        let helpbox = helptext.getBoundingClientRect();
+        comparetext.style.left = (helptext.offsetWidth + helptext.offsetLeft + 5) + 'px';
+        comparetext.style.top = helpbox.y + 'px';
+    }
+
     function displayHelp(caretId) {
         focusedNodeId = caretId;
         let helptext = document.getElementById("helptext");
@@ -284,6 +309,16 @@
         let caret = overlay.data('caret');
         let type = overlay.data('type');
         let content = getHelpText(name, id, type);
+
+        if (type.indexOf('UNIT') != -1 ) {
+            let compareDropdown = '<br>';
+            compareDropdown += `<select id="compare-unit-select" onchange="displayComparedUnit(this)">`;
+            compareDropdown += '<option value="">Compare to...</option>';
+            compareDropdown += Object.keys(data.meta.units).map(unitName => `<option>${unitName}</option>`).join('');
+            compareDropdown += '</select>';
+            content += compareDropdown;
+        }
+
         helptextContent.innerHTML = content;
 
         styleXRefBadges(name, type);
@@ -306,11 +341,13 @@
         }
         helptext.style.left = destX + 'px';
         resetHighlightPath();
+        comparetext.style.display = "none";
     }
 
     function hideHelp() {
         focusedNodeId = null;
         helptext.style.display = "none";
+        comparetext.style.display = "none";
         resetHighlightPath();
     }
 

--- a/style.css
+++ b/style.css
@@ -48,6 +48,15 @@ body {
     padding: 0.2rem;
     font-size: 10pt;
 }
+#comparetext {
+    position: absolute;
+    display: none;
+    width: 300px;
+    background-color: #eee;
+    border: 2px solid #bbb;
+    padding: 0.2rem;
+    font-size: 10pt;
+}
 
 #helptext__x_ref__container {
     /* There are 35 civs, 5x7 makes the badges into a nice square. */
@@ -119,6 +128,25 @@ body {
 }
 
 #civselect:focus {
+    outline: none;
+}
+
+#compare-unit-select {
+    font-weight: bold;
+    font-family: Georgia, 'Times New Roman', Times, serif;
+    background-color: #72604a;
+    flex: 1 0 auto;
+    color: white;
+    text-shadow: #000000 -3px 2px;
+    box-shadow: inset 0 2px #3f4806, inset 2px -2px #768141, inset -2px 0 #768141;
+    padding: 5px;
+}
+
+#compare-unit-select option {
+    text-shadow: none;
+}
+
+#compare-unit-select:focus {
     outline: none;
 }
 


### PR DESCRIPTION
Adds a drop down menu in the help text of units allowing you to easily compare the stats of one to another. 

- I copied the civselect style for the drop down, does it look okay at this smaller size? 
- Maybe add a title to the compare box that says "Compared to..." or similar

![image](https://user-images.githubusercontent.com/2628379/77836701-bfe34b80-712e-11ea-89ad-9c11e6a25ea3.png)

