### PR TITLE
Help / Info Popup Improvements

### DIFF
--- a/index.html
+++ b/index.html
@@ -87,7 +87,7 @@
                 <div id="helptext__content"></div>
                 <details>
                     <summary>Advanced Stats</summary>
-                    <div id="helptext__advance_stats"></div>
+                    <div id="helptext__advanced_stats"></div>
                     <div id="helptext__x_ref"><h3>Civilizations</h3></div>
                 </details>
               </div>
@@ -310,14 +310,14 @@
     function displayHelp(caretId) {
         focusedNodeId = caretId;
         let helptextContent = document.getElementById("helptext__content");
-        let helptextAdvanceStats = document.getElementById("helptext__advance_stats");
+        let helptextAdvancedStats = document.getElementById("helptext__advanced_stats");
         let overlay = SVG.get(`${caretId}_overlay`);
         let name = overlay.data('name');
         let id = overlay.data('id').replace('_copy', '');
         let caret = overlay.data('caret');
         let type = overlay.data('type');
         helptextContent.innerHTML = getHelpText(name, id, type);
-        helptextAdvanceStats.innerHTML = getAdvancedStats(name, id, type);
+        helptextAdvancedStats.innerHTML = getAdvancedStats(name, id, type);
         styleXRefBadges(name, id, type);
         positionHelptext(caret);
         resetHighlightPath();

--- a/index.html
+++ b/index.html
@@ -80,19 +80,18 @@
         <div id="techtree">
             <div id="helptext">
                 <div id="helptext__content"></div>
-                <div id="helptext__x_ref">
-                    <h3>Civilizations</h3>
-                </div>
+                <div id="helptext__advance_stats"></div>
+                <div id="helptext__x_ref"></div>
                 <div id="helptext__more">
-                    <a href="javascript:toggle_more_stats()">More Info &#x25BC;</a>
+                    <a href="javascript:toggle_more_stats()" id="helptext__more_link">More Info &#x25BC;</a>
                 </div>
               </div>
         </div>
     </div>
 </div>
-<script src="js/svg.min.js"></script>
-<script src="js/techtree.js"></script>
-<script src="js/civs.js"></script>
+<script type="text/javascript" src="js/svg.min.js"></script>
+<script type="text/javascript" src="js/techtree.js"></script>
+<script type="text/javascript" src="js/civs.js"></script>
 <script type="text/javascript">
     let tree;
     let data = {};
@@ -219,7 +218,9 @@
 
         loadCiv();
         // Make the xref badges
-        document.getElementById('helptext__x_ref').appendChild(createXRefBadges());
+        createXRefBadges();
+        // Hide Advance Stats and Civilizations
+        toggle_more_stats()
     });
 
     function imagePrefix(name) {
@@ -233,7 +234,9 @@
         const selectedCiv = document.getElementById('civselect').value;
         civ(selectedCiv, tree);
         if (selectedCiv in data.civ_helptexts) {
-            document.getElementById('civtext').innerHTML = data.strings[data.civ_helptexts[selectedCiv]];
+            let civText = data.strings[data.civ_helptexts[selectedCiv]];
+            civText = civText.replace(/(.*civilization\s*<br>\s*<br>)/m, "$1<b>Civilization Bonus</b><br>")
+            document.getElementById('civtext').innerHTML = civText;
             document.getElementById('civlogo').src = `./img/Civs/${selectedCiv.toLowerCase()}.png`;
             window.location.hash = selectedCiv;
         } else {
@@ -292,12 +295,14 @@
     function displayHelp(caretId) {
         focusedNodeId = caretId;
         let helptextContent = document.getElementById("helptext__content");
+        let helptextAdvanceStats = document.getElementById("helptext__advance_stats");
         let overlay = SVG.get(`${caretId}_overlay`);
         let name = overlay.data('name');
         let id = overlay.data('id').replace('_copy', '');
         let caret = overlay.data('caret');
         let type = overlay.data('type');
         helptextContent.innerHTML = getHelpText(name, id, type);
+        helptextAdvanceStats.innerHTML = getAdvanceStats(name, id, type);
         styleXRefBadges(name, id, type);
         positionHelptext(caret);
         resetHighlightPath();
@@ -364,7 +369,7 @@
         helptext.style.left = destX + 'px';
     }
 
-    function getHelpText(name, id, type) {
+    function getEntityType(type) {
         let entitytype = 'buildings';
         if (type === "UNIT" || type === "UNIQUEUNIT") {
             entitytype = 'units';
@@ -372,6 +377,11 @@
         if (type === "TECHNOLOGY") {
             entitytype = 'techs';
         }
+        return entitytype;
+    }
+
+    function getHelpText(name, id, type) {
+        let entitytype = getEntityType(type);
         const items = id.split('_', 1);
         id = id.substring(items[0].length + 1);
         let text = data.strings[data.data[entitytype][id]['LanguageHelpId']];
@@ -388,12 +398,11 @@
             text = text.replace(/(?<heading>.+?\(‹cost›\))(?<description>.+?)<i>\s*(?<upgrades>Upgrades:.+?)<\/i>(?<stats>.*)/m,
                 '<p>$<heading></p>' +
                 '<p>$<description></p>' +
-                '<p>$<upgrades></p>' +
+                '<p><em>$<upgrades></em></p>' +
                 '<p class="helptext__stats">$<stats></p>');
         }
         let meta = data.data[entitytype][id];
         if (meta !== undefined) {
-            console.log("Metadata found for " + name, meta);
             text = text.replace(/‹cost›/, "Cost: " + cost(meta.Cost));
             let stats = []
             if (text.match(/‹hp›/)) {
@@ -423,10 +432,21 @@
             stats.push(secondsIfDefined(meta.ReloadTime, "Reload Time:&nbsp;"));
             stats.push(accuracyIfDefined(meta.AccuracyPercent, "Accuracy:&nbsp;"));
             text = text.replace(/<p class="helptext__stats">(.+?)<\/p>/, "<h3>Stats</h3><p>" + stats.filter(Boolean).join(', ') + "<p>")
-            text += '<div id="helptext__advance_stats">';
+        } else {
+            console.error("No metadata found for " + name);
+        }
+        return text;
+    }
+
+    function getAdvanceStats(name, id, type) {
+        let entitytype = getEntityType(type);
+        const items = id.split('_', 1);
+        id = id.substring(items[0].length + 1);
+        let meta = data.data[entitytype][id];
+        let text = ''
+        if (meta !== undefined) {
             text += arrayIfDefinedAndNonEmpty(meta.Attacks, '<h3>Attacks</h3>');
             text += arrayIfDefinedAndNonEmpty(meta.Armours, '<h3>Armours</h3>');
-            text += '</div>';
         } else {
             console.error("No metadata found for " + name);
         }
@@ -440,9 +460,14 @@
      * @return A container with buttons + images for each civ to be used in cross referencing.
      */
      function createXRefBadges() {
+        let xRef = document.getElementById('helptext__x_ref');
+
+        let xRefTitle = document.createElement('h3');
+        xRefTitle.innerText = 'Civilizations';
+        xRef.appendChild(xRefTitle)
+
         let xRefLinks = document.createElement('div');
         xRefLinks.id = "helptext__x_ref__container";
-
         for (let civ of Object.keys(data.civ_names)) {
             let xRefLink = document.createElement('button');
             xRefLink.addEventListener('click', function() {
@@ -459,7 +484,7 @@
             xRefLink.appendChild(xRefImage);
             xRefLinks.appendChild(xRefLink);
         }
-        return xRefLinks;
+        xRef.appendChild(xRefLinks)
     }
 
     /** 
@@ -623,13 +648,15 @@
     function toggle_more_stats() {
         const stats = document.getElementById('helptext__advance_stats');
         const civs = document.getElementById('helptext__x_ref');
-        console.log(stats, civs)
+        const link = document.getElementById('helptext__more_link');
         if (civs.style.display === 'none') {
             stats.style.display = 'block';
             civs.style.display = 'block';
+            link.innerHTML = 'Less Info &#x25B2;';
         } else {
             stats.style.display = 'none';
             civs.style.display = 'none';
+            link.innerHTML = 'More Info &#x25BC;';
         }
     }
 

--- a/index.html
+++ b/index.html
@@ -245,7 +245,7 @@
         civ(selectedCiv, tree);
         if (selectedCiv in data.civ_helptexts) {
             let civText = data.strings[data.civ_helptexts[selectedCiv]];
-            civText = civText.replace(/(.*civilization\s*<br>\s*<br>)/m, "$1<b>Civilization Bonus</b><br>")
+            civText = civText.replace(/(.*civilization\s*<br>\s*<br>)/m, "$1<b>Civilization Bonus:</b><br>")
             document.getElementById('civtext').innerHTML = civText;
             document.getElementById('civlogo').src = `./img/Civs/${selectedCiv.toLowerCase()}.png`;
             window.location.hash = selectedCiv;

--- a/index.html
+++ b/index.html
@@ -60,31 +60,36 @@
             </div>
             <div class="info">
                 <p>
-                    Version: Age of Empires II DE Update <a href="https://www.ageofempires.com/news/aoe2de-update-36906/" target="_blank" title="Changelog">36906</a>
+                    Version: Age of Empires II DE Update <a href="https://www.ageofempires.com/news/aoe2de-update-36906/" target="_blank" title="Changelog" rel="nofollow">36906</a>
                 </p>
                 <p>
-                    Contribute on <a href="https://github.com/SiegeEngineers/aoe2techtree" target="_blank">GitHub</a>
-                </p>
-                <p>
-                    Made by hszemi, Anda, exterkamp, paulirish,<br>
-                    with thanks to Jineapple, TriRem, pip, and NkoDragaš<br>
-                    Item Metadata (cost, HP etc.) taken from <a href="https://github.com/HSZemi/aoe2dat" target="_blank">aoe2dat</a>
-                </p>
-                <p>
-                    Age of Empires II &copy; Microsoft Corporation.</br>
-                    <b>aoe2techtree</b> was created under Microsoft's "<a href="https://www.xbox.com/en-us/developers/rules">Game Content Usage Rules</a>" using assets
+                    Age of Empires II &copy; Microsoft Corporation.<br>
+                    <b>aoe2techtree</b> was created under Microsoft's "<a href="https://www.xbox.com/en-us/developers/rules" rel="nofollow">Game Content Usage Rules</a>" using assets
                     from Age of Empires II, and it is not endorsed by or affiliated with Microsoft.
                 </p>
+                <details>
+                    <summary>Credits</summary>
+                    <p>
+                        A project by <a href="https://aoe2.se" rel="author" class="has-text-grey">Siege Engineers</a>. Contribute on <a href="https://github.com/SiegeEngineers/aoe2techtree" target="_blank">GitHub</a>
+                    </p>
+                    <p>
+                        Made by hszemi, Anda, exterkamp, paulirish<br>
+                        with thanks to Jineapple, TriRem, pip, and NkoDragaš<br>
+                    </p>
+                    <p>
+                        Item Metadata (cost, HP etc.) taken from <a href="https://github.com/HSZemi/aoe2dat" target="_blank">aoe2dat</a>
+                    </p>
+                </details>
             </div>
         </div>
         <div id="techtree">
             <div id="helptext">
                 <div id="helptext__content"></div>
-                <div id="helptext__advance_stats"></div>
-                <div id="helptext__x_ref"></div>
-                <div id="helptext__more">
-                    <a href="javascript:toggle_more_stats()" id="helptext__more_link">More Info &#x25BC;</a>
-                </div>
+                <details>
+                    <summary>Advanced Stats</summary>
+                    <div id="helptext__advance_stats"></div>
+                    <div id="helptext__x_ref"><h3>Civilizations</h3></div>
+                </details>
               </div>
         </div>
     </div>
@@ -312,7 +317,7 @@
         let caret = overlay.data('caret');
         let type = overlay.data('type');
         helptextContent.innerHTML = getHelpText(name, id, type);
-        helptextAdvanceStats.innerHTML = getAdvanceStats(name, id, type);
+        helptextAdvanceStats.innerHTML = getAdvancedStats(name, id, type);
         styleXRefBadges(name, id, type);
         positionHelptext(caret);
         resetHighlightPath();
@@ -437,7 +442,7 @@
         return text;
     }
 
-    function getAdvanceStats(name, id, type) {
+    function getAdvancedStats(name, id, type) {
         let entitytype = getEntityType(type);
         const items = id.split('_', 1);
         id = id.substring(items[0].length + 1);
@@ -471,11 +476,6 @@
      */
      function createXRefBadges() {
         let xRef = document.getElementById('helptext__x_ref');
-
-        let xRefTitle = document.createElement('h3');
-        xRefTitle.innerText = 'Civilizations';
-        xRef.appendChild(xRefTitle)
-
         let xRefLinks = document.createElement('div');
         xRefLinks.id = "helptext__x_ref__container";
         for (let civ of Object.keys(data.civ_names)) {
@@ -637,7 +637,6 @@
         }
     }
 
-
     function cost(cost_object) {
         let value = "";
         if ("Food" in cost_object) {
@@ -654,22 +653,6 @@
         }
         return value;
     }
-
-    function toggle_more_stats() {
-        const stats = document.getElementById('helptext__advance_stats');
-        const civs = document.getElementById('helptext__x_ref');
-        const link = document.getElementById('helptext__more_link');
-        if (civs.style.display === 'none') {
-            stats.style.display = 'block';
-            civs.style.display = 'block';
-            link.innerHTML = 'Less Info &#x25B2;';
-        } else {
-            stats.style.display = 'none';
-            civs.style.display = 'none';
-            link.innerHTML = 'More Info &#x25BC;';
-        }
-    }
-
 </script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -80,7 +80,12 @@
         <div id="techtree">
             <div id="helptext">
                 <div id="helptext__content"></div>
-                <div id="helptext__x_ref"></div>
+                <div id="helptext__x_ref">
+                    <h3>Civilizations</h3>
+                </div>
+                <div id="helptext__more">
+                    <a href="javascript:toggle_more_stats()">More Info &#x25BC;</a>
+                </div>
               </div>
         </div>
     </div>
@@ -373,30 +378,59 @@
         if (text === undefined) {
             return "?";
         }
+        text = text.replace(/\s<br>/g, '');
+        text = text.replace(/\n/g, '');
+        if (type === "TECHNOLOGY") {
+            text = text.replace(/(?<heading>.+?\(‹cost›\))(?<description>.*)/m,
+                '<p class="helptext__heading">$<heading></p>' +
+                '<p class="helptext__desc">$<description></p>');
+        } else {
+            text = text.replace(/(?<heading>.+?\(‹cost›\))(?<description>.+?)<i>\s*(?<upgrades>Upgrades:.+?)<\/i>(?<stats>.*)/m,
+                '<p>$<heading></p>' +
+                '<p>$<description></p>' +
+                '<p>$<upgrades></p>' +
+                '<p class="helptext__stats">$<stats></p>');
+        }
         let meta = data.data[entitytype][id];
         if (meta !== undefined) {
+            console.log("Metadata found for " + name, meta);
             text = text.replace(/‹cost›/, "Cost: " + cost(meta.Cost));
-            text = text.replace(/‹hp›/, "HP:&nbsp;" + meta.HP + ",");
-            text = text.replace(/‹attack›/, "Attack:&nbsp;" + meta.Attack + ",");
-            text = text.replace(/‹(A|a)rmor›/, "Armor:&nbsp;" + meta.MeleeArmor + ",");
-            text = text.replace(/‹(P|p)iercearmor›/, "Piercearmor:&nbsp;" + meta.PierceArmor + ",");
-            text = text.replace(/‹garrison›/, "Garrison:&nbsp;" + meta.GarrisonCapacity + ",");
-            text = text.replace(/‹range›/, "Range:&nbsp;" + meta.Range + ",");
-            text += minRangeIfDefined(meta.MinRange, "Min Range:&nbsp;");
-            text += ifDefined(meta.LineOfSight, "Line of Sight:&nbsp;");
-            text += ifDefined(meta.Speed, "Speed:&nbsp;");
-            text += secondsIfDefined(meta.TrainTime, "Build Time:&nbsp;");
-            text += secondsIfDefined(meta.ResearchTime, "Research Time:&nbsp;");
-            text += ifDefined(meta.FrameDelay, "Frame Delay:&nbsp;");
-            text += secondsIfDefined(meta.ReloadTime, "Reload Time:&nbsp;");
-            text += accuracyIfDefined(meta.AccuracyPercent, "Accuracy:&nbsp;");
-            text += arrayIfDefinedAndNonEmpty(meta.Attacks, "<br>Attacks:&nbsp;");
-            text += arrayIfDefinedAndNonEmpty(meta.Armours, "<br>Armours:&nbsp;");
+            let stats = []
+            if (text.match(/‹hp›/)) {
+                stats.push("HP:&nbsp;" + meta.HP);
+            }
+            if (text.match(/‹attack›/)) {
+                stats.push("Attack:&nbsp;" + meta.Attack);
+            }
+            if (text.match(/‹(A|a)rmor›/)) {
+                stats.push("Armor:&nbsp;" + meta.MeleeArmor);
+            }
+            if (text.match(/‹(P|p)iercearmor›/)) {
+                stats.push("Pierce armor:&nbsp;" + meta.PierceArmor);
+            }
+            if (text.match(/‹garrison›/)) {
+                stats.push("Garrison:&nbsp;" + meta.GarrisonCapacity);
+            }
+            if (text.match(/‹range›/)) {
+                stats.push("Range:&nbsp;" + meta.Range);
+            }
+            stats.push(minRangeIfDefined(meta.MinRange, "Min Range:&nbsp;"));
+            stats.push(ifDefined(meta.LineOfSight, "Line of Sight:&nbsp;"));
+            stats.push(ifDefined(meta.Speed, "Speed:&nbsp;"));
+            stats.push(secondsIfDefined(meta.TrainTime, "Build Time:&nbsp;"));
+            stats.push(secondsIfDefined(meta.ResearchTime, "Research Time:&nbsp;"));
+            stats.push(ifDefined(meta.FrameDelay, "Frame Delay:&nbsp;"));
+            stats.push(secondsIfDefined(meta.ReloadTime, "Reload Time:&nbsp;"));
+            stats.push(accuracyIfDefined(meta.AccuracyPercent, "Accuracy:&nbsp;"));
+            text = text.replace(/<p class="helptext__stats">(.+?)<\/p>/, "<h3>Stats</h3><p>" + stats.filter(Boolean).join(', ') + "<p>")
+            text += '<div id="helptext__advance_stats">';
+            text += arrayIfDefinedAndNonEmpty(meta.Attacks, '<h3>Attacks</h3>');
+            text += arrayIfDefinedAndNonEmpty(meta.Armours, '<h3>Armours</h3>');
+            text += '</div>';
         } else {
-            console.log("No metadata found for " + name);
+            console.error("No metadata found for " + name);
         }
-        return text.substring(0, text.length - 1);
-
+        return text;
     }
 
     /**
@@ -524,7 +558,7 @@
 
     function ifDefined(value, prefix) {
         if (value !== undefined) {
-            return " " + prefix + value + ",";
+            return " " + prefix + value;
         } else {
             return "";
         }
@@ -532,7 +566,7 @@
 
     function secondsIfDefined(value, prefix) {
         if (value !== undefined) {
-            return " " + prefix + value + "s,";
+            return " " + prefix + value + "s";
         } else {
             return "";
         }
@@ -540,7 +574,7 @@
 
     function accuracyIfDefined(value, prefix) {
         if (value !== undefined && value < 100) {
-            return " " + prefix + value + "%,";
+            return " " + prefix + value + "%";
         } else {
             return "";
         }
@@ -548,7 +582,7 @@
 
     function minRangeIfDefined(value, prefix) {
         if (value !== undefined && value > 0) {
-            return " " + prefix + value + ",";
+            return " " + prefix + value;
         } else {
             return "";
         }
@@ -564,7 +598,7 @@
                 const clazz = unitClasses[attack['Class']];
                 strings.push(`${amount} (${clazz})`);
             }
-            return " " + prefix + strings.join(', ') + ",";
+            return prefix + '<p>' + strings.join(', ') + "</p>";
         }
     }
 
@@ -586,6 +620,18 @@
         return value;
     }
 
+    function toggle_more_stats() {
+        const stats = document.getElementById('helptext__advance_stats');
+        const civs = document.getElementById('helptext__x_ref');
+        console.log(stats, civs)
+        if (civs.style.display === 'none') {
+            stats.style.display = 'block';
+            civs.style.display = 'block';
+        } else {
+            stats.style.display = 'none';
+            civs.style.display = 'none';
+        }
+    }
 
 </script>
 </body>

--- a/index.html
+++ b/index.html
@@ -7,7 +7,7 @@
     <meta charset="utf-8"/>
     <title>Age of Empires II Tech Tree</title>
     <link rel="stylesheet" href="style.css">
-    <link href="https://fonts.googleapis.com/css2?family=Merriweather:ital,wght@0,300;0,400;0,700;1,300;1,400;1,700&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Merriweather:ital,wght@0,300;0,400;0,700;1,300;1,400;1,700&display=swap">
 </head>
 
 <body>

--- a/index.html
+++ b/index.html
@@ -379,17 +379,6 @@
         helptext.style.left = destX + 'px';
     }
 
-    function getEntityType(type) {
-        let entitytype = 'buildings';
-        if (type === "UNIT" || type === "UNIQUEUNIT") {
-            entitytype = 'units';
-        }
-        if (type === "TECHNOLOGY") {
-            entitytype = 'techs';
-        }
-        return entitytype;
-    }
-
     function getHelpText(name, id, type) {
         let entitytype = getEntityType(type);
         const items = id.split('_', 1);
@@ -461,6 +450,17 @@
             console.error("No metadata found for " + name);
         }
         return text;
+    }
+
+    function getEntityType(type) {
+        let entitytype = 'buildings';
+        if (type === "UNIT" || type === "UNIQUEUNIT") {
+            entitytype = 'units';
+        }
+        if (type === "TECHNOLOGY") {
+            entitytype = 'techs';
+        }
+        return entitytype;
     }
 
     /**

--- a/index.html
+++ b/index.html
@@ -234,8 +234,6 @@
         loadCiv();
         // Make the xref badges
         createXRefBadges();
-        // Hide Advance Stats and Civilizations
-        toggle_more_stats()
     });
 
     function imagePrefix(name) {

--- a/index.html
+++ b/index.html
@@ -63,23 +63,20 @@
                     Version: Age of Empires II DE Update <a href="https://www.ageofempires.com/news/aoe2de-update-36906/" target="_blank" title="Changelog" rel="nofollow">36906</a>
                 </p>
                 <p>
+                    A project by <a href="https://aoe2.se" rel="author" class="has-text-grey">Siege Engineers</a>. Contribute on <a href="https://github.com/SiegeEngineers/aoe2techtree" target="_blank">GitHub</a>
+                </p>
+                <p>
+                    Made by hszemi, Anda, exterkamp, paulirish<br>
+                    with thanks to Jineapple, TriRem, pip, and NkoDragaš<br>
+                </p>
+                <p>
+                    Item Metadata (cost, HP etc.) taken from <a href="https://github.com/HSZemi/aoe2dat" target="_blank">aoe2dat</a>
+                </p>
+                <p>
                     Age of Empires II &copy; Microsoft Corporation.<br>
                     <b>aoe2techtree</b> was created under Microsoft's "<a href="https://www.xbox.com/en-us/developers/rules" rel="nofollow">Game Content Usage Rules</a>" using assets
                     from Age of Empires II, and it is not endorsed by or affiliated with Microsoft.
                 </p>
-                <details>
-                    <summary>Credits</summary>
-                    <p>
-                        A project by <a href="https://aoe2.se" rel="author" class="has-text-grey">Siege Engineers</a>. Contribute on <a href="https://github.com/SiegeEngineers/aoe2techtree" target="_blank">GitHub</a>
-                    </p>
-                    <p>
-                        Made by hszemi, Anda, exterkamp, paulirish<br>
-                        with thanks to Jineapple, TriRem, pip, and NkoDragaš<br>
-                    </p>
-                    <p>
-                        Item Metadata (cost, HP etc.) taken from <a href="https://github.com/HSZemi/aoe2dat" target="_blank">aoe2dat</a>
-                    </p>
-                </details>
             </div>
         </div>
         <div id="techtree">

--- a/index.html
+++ b/index.html
@@ -395,15 +395,15 @@
         text = text.replace(/\s<br>/g, '');
         text = text.replace(/\n/g, '');
         if (type === "TECHNOLOGY") {
-            text = text.replace(/(?<heading>.+?\(‹cost›\))(?<description>.*)/m,
-                '<p class="helptext__heading">$<heading></p>' +
-                '<p class="helptext__desc">$<description></p>');
+            text = text.replace(/(.+?\(‹cost›\))(.*)/m,
+                '<p class="helptext__heading">$1</p>' +
+                '<p class="helptext__desc">$2</p>');
         } else {
-            text = text.replace(/(?<heading>.+?\(‹cost›\))(?<description>.+?)<i>\s*(?<upgrades>Upgrades:.+?)<\/i>(?<stats>.*)/m,
-                '<p>$<heading></p>' +
-                '<p>$<description></p>' +
-                '<p><em>$<upgrades></em></p>' +
-                '<p class="helptext__stats">$<stats></p>');
+            text = text.replace(/(.+?\(‹cost›\))(.+?)<i>\s*(Upgrades:.+?)<\/i>(.*)/m,
+                '<p>$1</p>' +
+                '<p>$2</p>' +
+                '<p><em>$3</em></p>' +
+                '<p class="helptext__stats">$4</p>');
         }
         let meta = data.data[entitytype][id];
         if (meta !== undefined) {

--- a/index.html
+++ b/index.html
@@ -249,9 +249,7 @@
         const selectedCiv = document.getElementById('civselect').value;
         civ(selectedCiv, tree);
         if (selectedCiv in data.civ_helptexts) {
-            let civText = data.strings[data.civ_helptexts[selectedCiv]];
-            civText = civText.replace(/(.*civilization\s*<br>\s*<br>)/m, "$1<b>Civilization Bonus:</b><br>")
-            document.getElementById('civtext').innerHTML = civText;
+            document.getElementById('civtext').innerHTML = data.strings[data.civ_helptexts[selectedCiv]];
             document.getElementById('civlogo').src = `./img/Civs/${selectedCiv.toLowerCase()}.png`;
             window.location.hash = selectedCiv;
         } else {

--- a/style.css
+++ b/style.css
@@ -53,6 +53,7 @@ a, a:hover, a:visited, a:active {
     border: 2px solid #bbb;
     padding: 0.4rem;
     font-size: 10pt;
+    margin:5px;
 }
 
 #helptext p {

--- a/style.css
+++ b/style.css
@@ -50,7 +50,7 @@ a, a:hover, a:visited, a:active {
     display: none;
     width: 300px;
     background-color: #eee;
-    border: 1px solid #bbb;
+    border: 2px solid #bbb;
     padding: 0.4rem;
     font-size: 10pt;
 }

--- a/style.css
+++ b/style.css
@@ -3,7 +3,7 @@ body {
     width: 100%;
     height: 100%;
     box-sizing: border-box;
-    --xRef-badge-size: 30px;
+    --xRef-badge-size: 40px;
 }
 
 body, input, select {
@@ -17,6 +17,10 @@ body {
     justify-content: center;
     align-items: center;
     background: url("img/Backgrounds/bg_aoe2_hd_paper.jpg") repeat;
+}
+
+a, a:hover, a:visited, a:active {
+    color: #4d3617;
 }
 
 .info,
@@ -44,9 +48,10 @@ body {
     display: none;
     width: 300px;
     background-color: #eee;
-    border: 2px solid #bbb;
-    padding: 0.2rem;
+    /*border: 2px solid #bbb;*/
+    padding: 0.4rem;
     font-size: 10pt;
+    box-shadow: 1px 1px 8px 1px #906428;
 }
 
 #helptext__x_ref__container {
@@ -67,6 +72,23 @@ body {
 #helptext #helptext__x_ref div button img {
     width: var(--xRef-badge-size);
     height: var(--xRef-badge-size);
+}
+
+/*.helptext__stats, .helptext__upgrades, .helptext__desc, .helptext__heading {*/
+#helptext p {
+    margin-top: 0px;
+}
+
+.helptext__upgrades {
+    font-style: italic;
+}
+
+#helptext h3 {
+    font-family: sans-serif;
+    font-size: 0.87em;
+    text-transform: uppercase;
+    color: #4d3617;
+    margin-bottom: 5px;
 }
 
 #wrapper {

--- a/style.css
+++ b/style.css
@@ -47,7 +47,6 @@ a, a:hover, a:visited, a:active {
     display: none;
     width: 300px;
     background-color: #eee;
-    /*border: 2px solid #bbb;*/
     padding: 0.4rem;
     font-size: 10pt;
     box-shadow: 1px 1px 8px 1px #906428;

--- a/style.css
+++ b/style.css
@@ -3,7 +3,7 @@ body {
     width: 100%;
     height: 100%;
     box-sizing: border-box;
-    --xRef-badge-size: 40px;
+    --xRef-badge-size: 30px;
 }
 
 body, input, select {
@@ -55,6 +55,20 @@ a, a:hover, a:visited, a:active {
     font-size: 10pt;
 }
 
+#helptext p {
+    margin-top: 0;
+    margin-bottom: 15px;
+}
+
+#helptext h3 {
+    font-family: sans-serif;
+    font-size: 9pt;
+    text-transform: uppercase;
+    color: #4d3617;
+    margin: 2px 10px 0 0;
+    float: left;
+}
+
 #helptext__x_ref__container {
     /* There are 35 civs, 5x7 makes the badges into a nice square. */
     max-width: calc(var(--xRef-badge-size) * 7);
@@ -75,17 +89,8 @@ a, a:hover, a:visited, a:active {
     height: var(--xRef-badge-size);
 }
 
-#helptext p {
-    margin-top: 0;
-    margin-bottom: 15px;
-}
-
-#helptext h3 {
-    font-family: sans-serif;
-    font-size: 9pt;
-    text-transform: uppercase;
-    color: #4d3617;
-    margin-bottom: 5px;
+#helptext__x_ref h3 {
+    float: none;
 }
 
 #helptext summary {

--- a/style.css
+++ b/style.css
@@ -23,9 +23,12 @@ a, a:hover, a:visited, a:active {
     color: #4d3617;
 }
 
-.info p {
+.info {
     font-size: 8pt;
     color: #4d3617;
+}
+
+.info p {
     margin-top: 0;
 }
 
@@ -47,9 +50,9 @@ a, a:hover, a:visited, a:active {
     display: none;
     width: 300px;
     background-color: #eee;
+    border: 1px solid #bbb;
     padding: 0.4rem;
     font-size: 10pt;
-    box-shadow: 1px 1px 8px 1px #906428;
 }
 
 #helptext__x_ref__container {
@@ -85,15 +88,12 @@ a, a:hover, a:visited, a:active {
     margin-bottom: 5px;
 }
 
-#helptext__more {
-    text-align: center;
-}
-
-#helptext__more a {
+#helptext summary {
     font-family: sans-serif;
     font-size: 8pt;
-    text-decoration: none;
+    color: #4d3617;
     text-transform: uppercase;
+    cursor: pointer;
 }
 
 #wrapper {

--- a/style.css
+++ b/style.css
@@ -53,7 +53,6 @@ a, a:hover, a:visited, a:active {
     border: 2px solid #bbb;
     padding: 0.4rem;
     font-size: 10pt;
-    margin:5px;
 }
 
 #helptext p {

--- a/style.css
+++ b/style.css
@@ -8,7 +8,7 @@ body {
 
 body, input, select {
     font-family: 'Merriweather', Georgia, 'Times New Roman', Times, serif;
-    line-height: 1.25em;
+    line-height: 1.6;
 }
 
 body {
@@ -23,11 +23,10 @@ a, a:hover, a:visited, a:active {
     color: #4d3617;
 }
 
-.info,
-.info a {
+.info p {
     font-size: 8pt;
-    display: inline;
     color: #4d3617;
+    margin-top: 0;
 }
 
 #container {
@@ -74,21 +73,28 @@ a, a:hover, a:visited, a:active {
     height: var(--xRef-badge-size);
 }
 
-/*.helptext__stats, .helptext__upgrades, .helptext__desc, .helptext__heading {*/
 #helptext p {
-    margin-top: 0px;
-}
-
-.helptext__upgrades {
-    font-style: italic;
+    margin-top: 0;
+    margin-bottom: 15px;
 }
 
 #helptext h3 {
     font-family: sans-serif;
-    font-size: 0.87em;
+    font-size: 9pt;
     text-transform: uppercase;
     color: #4d3617;
     margin-bottom: 5px;
+}
+
+#helptext__more {
+    text-align: center;
+}
+
+#helptext__more a {
+    font-family: sans-serif;
+    font-size: 8pt;
+    text-decoration: none;
+    text-transform: uppercase;
 }
 
 #wrapper {


### PR DESCRIPTION
### Summary
Changed a bunch of things in the Help / Info Popup to improve readability:

1. Grouped various stats into Stats, Attacks and Armours.
2. Added some margin between sections
3. Hide advanced stats by default and show it when the user clicks 'More Info' link
4. Increased the size of civ images in the info popup to use up the available width
5. Added a drop shadow to the info popup instead of a border

### Before
![before](https://user-images.githubusercontent.com/13775/81038749-c484e780-8ec4-11ea-9309-5deb48878718.png)

### After
![one](https://user-images.githubusercontent.com/13775/81038761-cea6e600-8ec4-11ea-954e-c9135c3f0c46.png)
![two](https://user-images.githubusercontent.com/13775/81038764-d070a980-8ec4-11ea-9087-ff45ac00e1c6.png)