### PR TITLE
fix: increases opacity for cross (for colorblinds)

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -167,10 +167,6 @@ function displayData() {
                     id: `${caret.id}_bg`
                 }).move(caret.x, caret.y);
                 let name = formatName(caret.name);
-                var text = item.text(name.toString())
-                    .font({size: 9, weight: 'bold'})
-                    .attr({fill: '#ffffff', opacity:0.95, 'text-anchor': 'middle', id: caret.id + '_text'})
-                    .move(caret.x + caret.width / 2, caret.y + caret.height / 1.5);
                 var image_placeholder = item.rect(caret.width * 0.6, caret.height * 0.6)
                     .attr({fill: '#000000', opacity:0.5, id: caret.id + '_imgph'})
                     .move(caret.x + caret.width * 0.2, caret.y);
@@ -178,11 +174,18 @@ function displayData() {
                 var image = item.image(prefix + imagePrefix(caret.id) + '.png', caret.width * 0.6, caret.height * 0.6)
                     .attr({id: caret.id + '_img'})
                     .move(caret.x + caret.width * 0.2, caret.y);
+                var crossBackground = item.rect(caret.width, caret.height)
+                    .attr({id: caret.id + '_x_bg', fill: '#232323', opacity: 0.8})
+                    .move(caret.x, caret.y);
+                var text = item.text(name.toString())
+                    .font({size: 9, weight: 'bold'})
+                    .attr({fill: '#ffffff', opacity:0.95, 'text-anchor': 'middle', id: caret.id + '_text'})
+                    .move(caret.x + caret.width / 2, caret.y + caret.height / 1.5);
                 var cross = item.polygon([1, 0, 3, 2, 5, 0, 6, 1, 4, 3, 6, 5, 5, 6, 3, 4, 1, 6, 0, 5, 2, 3, 0, 1])
-                    .attr({fill: '#ff0000', opacity:0.8, id: caret.id + '_x'})
+                    .attr({fill: '#910000', opacity:0.6, id: caret.id + '_x'})
                     .addClass('cross')
-                    .size(caret.width * 0.6, caret.height * 0.6)
-                    .move(caret.x + caret.width * 0.2, caret.y);
+                    .size(caret.width * 0.7, caret.height * 0.7)
+                    .move(caret.x + caret.width * 0.15, caret.y);
                 var overlaytrigger = item.rect(caret.width, caret.height)
                     .attr({id: caret.id + '_overlay'})
                     .addClass('node__overlay')

--- a/js/main.js
+++ b/js/main.js
@@ -179,7 +179,7 @@ function displayData() {
                     .attr({id: caret.id + '_img'})
                     .move(caret.x + caret.width * 0.2, caret.y);
                 var cross = item.polygon([1, 0, 3, 2, 5, 0, 6, 1, 4, 3, 6, 5, 5, 6, 3, 4, 1, 6, 0, 5, 2, 3, 0, 1])
-                    .attr({fill: '#ff0000', opacity:0.5, id: caret.id + '_x'})
+                    .attr({fill: '#ff0000', opacity:0.8, id: caret.id + '_x'})
                     .addClass('cross')
                     .size(caret.width * 0.6, caret.height * 0.6)
                     .move(caret.x + caret.width * 0.2, caret.y);

--- a/js/techtree.js
+++ b/js/techtree.js
@@ -536,12 +536,15 @@ function checkIdUnique(tree) {
 function enable(buildings, units, techs) {
     for (let name of buildings) {
         SVG.get('building_' + formatId(name) + '_x').attr({'fill-opacity': 0});
+        SVG.get('building_' + formatId(name) + '_x_bg').attr({'fill-opacity': 0});
     }
     for (let name of units) {
         SVG.get('unit_' + formatId(name) + '_x').attr({'fill-opacity': 0});
+        SVG.get('unit_' + formatId(name) + '_x_bg').attr({'fill-opacity': 0});
     }
     for (let name of techs) {
         SVG.get('tech_' + formatId(name) + '_x').attr({'fill-opacity': 0});
+        SVG.get('tech_' + formatId(name) + '_x_bg').attr({'fill-opacity': 0});
     }
 }
 


### PR DESCRIPTION
Hey, I was watching a stream from rlyknght. [He somehow complained about the cross not being visible for coloublinds](https://clips.twitch.tv/LuckyPuzzledRingBleedPurple-XM5oXYsg2Vfmt6x0).

If we add +30% opacity, it gets better.

Before / after:
<img width="1076" alt="Screenshot 2021-10-24 at 20 24 16" src="https://user-images.githubusercontent.com/6160970/138607515-9441fa30-c81a-4c0d-9d00-fe4103b23306.png">



Before / after: (in Chrome > emulate vision deficiencies > Protanopia) - upgrades like thumbring were barely noticeable.
<img width="1369" alt="Screenshot 2021-10-24 at 20 23 49" src="https://user-images.githubusercontent.com/6160970/138607520-eb84a684-5438-4a5d-a68e-0ada52bb4904.png">


Btw thanks for this app I love it <3