### PR TITLE
fix: remove non standard rel=shortcut

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
 
 <head>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <link rel="shortcut icon" type="image/png" href="img/favicon.png">
+    <link rel="icon" type="image/png" href="img/favicon.png">
     <meta charset="utf-8"/>
     <title>Age of Empires II Tech Tree</title>
     <link rel="alternate" hreflang="x-default" href="https://aoe2techtree.net" />


### PR DESCRIPTION
`shortcut` is used by IE6 which is dead and does not support `png` favicons.