### PR TITLE
Support <static_cost=res,cost> as used by Spies

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -521,6 +521,11 @@ function getHelpText(name, id, type) {
         let displayAttack = false;
         let ranged = meta.Range > 1;
         text = text.replace(/‹cost›/, cost(meta.Cost));
+        // The format is ‹static_cost=Gold,200› as with Spies/Treason.
+        text = text.replaceAll(/‹static_cost=([^,›]*),([^›]*)›/g, (_, resource, cost) => {
+          const className = resource.toLowerCase();
+          return `<span class="cost ${className}" title="${cost} ${resource}">${cost}</span>`;
+        });
         let stats = []
         if (text.match(/‹hp›/)) {
             stats.push('HP:&nbsp;' + meta.HP);


### PR DESCRIPTION
Spies/Treason has some special syntax for the cost, this adds support for that.

Currently it shows like this:
![image](https://user-images.githubusercontent.com/351085/237058333-8f8e1565-9db0-459e-8bf9-1280949f5d15.png)
afterwards it looks like this:
![image](https://user-images.githubusercontent.com/351085/237058507-ff7aed21-109f-4b2b-a7db-8526bbcae2ac.png)
