### PR TITLE
Migrate obsolete attributes to CSS

### DIFF
--- a/index.html
+++ b/index.html
@@ -80,12 +80,12 @@
             </div>
             <div class="buildingindex">
                 <hr>
-                <table border="0" cellspacing="5" id="buildingindex__table">
+                <table id="buildingindex__table">
                 </table>
             </div>
             <div class="key">
                 <b id="key__label"></b>
-                <table border="0" cellspacing="10" id="key__table">
+                <table id="key__table">
                 </table>
             </div>
             <div class="locale-switcher">

--- a/style.css
+++ b/style.css
@@ -201,6 +201,13 @@ hr:before {
 
 #buildingindex__table {
     margin: auto;
+    border: none;
+    border-spacing: 5px;
+}
+
+#key__table {
+    border: none;
+    border-spacing: 10px;
 }
 
 .locale-switcher {


### PR DESCRIPTION
Fix finding by https://validator.w3.org/nu/about.html

* Error: The border attribute on the table element is obsolete. Use CSS instead.
* Error: The cellspacing attribute on the table element is obsolete. Use CSS instead.