### PR TITLE
Remove trailing slash on void element

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,26 +4,26 @@
 <head>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link rel="icon" type="image/png" href="img/favicon.png">
-    <meta charset="utf-8"/>
+    <meta charset="utf-8">
     <title>Age of Empires II Tech Tree</title>
-    <link rel="alternate" hreflang="x-default" href="https://aoe2techtree.net" />
-    <link rel="alternate" hreflang="en" href="https://aoe2techtree.net/?lng=en" />
-    <link rel="alternate" hreflang="zh-CN" href="https://aoe2techtree.net/?lng=zh" />
-    <link rel="alternate" hreflang="zh-TW" href="https://aoe2techtree.net/?lng=tw" />
-    <link rel="alternate" hreflang="fr" href="https://aoe2techtree.net/?lng=fr" />
-    <link rel="alternate" hreflang="de" href="https://aoe2techtree.net/?lng=de" />
-    <link rel="alternate" hreflang="hi" href="https://aoe2techtree.net/?lng=hi" />
-    <link rel="alternate" hreflang="it" href="https://aoe2techtree.net/?lng=it" />
-    <link rel="alternate" hreflang="ja" href="https://aoe2techtree.net/?lng=jp" />
-    <link rel="alternate" hreflang="ko" href="https://aoe2techtree.net/?lng=ko" />
-    <link rel="alternate" hreflang="ms" href="https://aoe2techtree.net/?lng=ms" />
-    <link rel="alternate" hreflang="pl" href="https://aoe2techtree.net/?lng=pl" />
-    <link rel="alternate" hreflang="ru" href="https://aoe2techtree.net/?lng=ru" />
-    <link rel="alternate" hreflang="es-ES" href="https://aoe2techtree.net/?lng=es" />
-    <link rel="alternate" hreflang="es-MX" href="https://aoe2techtree.net/?lng=mx" />
-    <link rel="alternate" hreflang="tr" href="https://aoe2techtree.net/?lng=tr" />
-    <link rel="alternate" hreflang="vi" href="https://aoe2techtree.net/?lng=vi" />
-    <link rel="alternate" hreflang="pt-BR" href="https://aoe2techtree.net/?lng=br" />
+    <link rel="alternate" hreflang="x-default" href="https://aoe2techtree.net">
+    <link rel="alternate" hreflang="en" href="https://aoe2techtree.net/?lng=en">
+    <link rel="alternate" hreflang="zh-CN" href="https://aoe2techtree.net/?lng=zh">
+    <link rel="alternate" hreflang="zh-TW" href="https://aoe2techtree.net/?lng=tw">
+    <link rel="alternate" hreflang="fr" href="https://aoe2techtree.net/?lng=fr">
+    <link rel="alternate" hreflang="de" href="https://aoe2techtree.net/?lng=de">
+    <link rel="alternate" hreflang="hi" href="https://aoe2techtree.net/?lng=hi">
+    <link rel="alternate" hreflang="it" href="https://aoe2techtree.net/?lng=it">
+    <link rel="alternate" hreflang="ja" href="https://aoe2techtree.net/?lng=jp">
+    <link rel="alternate" hreflang="ko" href="https://aoe2techtree.net/?lng=ko">
+    <link rel="alternate" hreflang="ms" href="https://aoe2techtree.net/?lng=ms">
+    <link rel="alternate" hreflang="pl" href="https://aoe2techtree.net/?lng=pl">
+    <link rel="alternate" hreflang="ru" href="https://aoe2techtree.net/?lng=ru">
+    <link rel="alternate" hreflang="es-ES" href="https://aoe2techtree.net/?lng=es">
+    <link rel="alternate" hreflang="es-MX" href="https://aoe2techtree.net/?lng=mx">
+    <link rel="alternate" hreflang="tr" href="https://aoe2techtree.net/?lng=tr">
+    <link rel="alternate" hreflang="vi" href="https://aoe2techtree.net/?lng=vi">
+    <link rel="alternate" hreflang="pt-BR" href="https://aoe2techtree.net/?lng=br">
     <link rel="stylesheet" href="fonts/merriweather.css">
     <link rel="stylesheet" href="style.css">
 </head>


### PR DESCRIPTION
Fix finding by https://validator.w3.org/nu/about.html

* Info: Trailing slash on void elements has no effect and interacts badly with unquoted attribute values.