### PR TITLE
Fix missing attributes for img

### DIFF
--- a/index.html
+++ b/index.html
@@ -74,7 +74,7 @@
                         <option>Vietnamese</option>
                         <option>Vikings</option>
                     </select>
-                    <img id="civlogo" height="81" width="81" data-transparent="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII=">
+                    <img id="civlogo" height="81" width="81" data-transparent="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII=" src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII=" alt="">
                 </div>
                 <p id="civtext"></p>
             </div>


### PR DESCRIPTION
Fix finding by https://validator.w3.org/nu/about.html Error: Element img is missing required attribute src. Error: An img element must have an alt attribute, except under certain conditions.