### PR TITLE
Hiding certain armor classes from being displayed

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -679,10 +679,15 @@ function ifDefinedAndGreaterZero(value, prefix) {
 function arrayIfDefinedAndNonEmpty(attacks, prefix) {
     if (attacks !== undefined && 0 < attacks.length) {
         const strings = [];
+        // Hiding these armor classes from being displayed because no units have attack bonuses against them
+        const unusedArmorClasses = [0, 36, 40];
+        const obsoleteArmorClasses = [31]; // hiding these - because there is no purpose of showing them
         for (let attack of attacks) {
             const amount = attack['Amount'];
-            const clazz = unitClasses[attack['Class']];
-            strings.push(`${amount} (${clazz})`);
+            if (!obsoleteArmorClasses.includes(attack['Class']) && !unusedArmorClasses.includes(attack['Class'])) {
+                const clazz = unitClasses[attack['Class']];
+                strings.push(`${amount} (${clazz})`);
+            }
         }
         return prefix + '<p>' + strings.join(', ') + '</p>';
     }

--- a/js/techtree.js
+++ b/js/techtree.js
@@ -24,7 +24,7 @@ const getAgeNames = (data)=>{
 }
 
 const unitClasses = {
-    0: '<abbr title="unused">Wonders</abbr>',
+    0: 'Wonders',
     1: 'Infantry',
     2: 'Heavy Warships',
     3: 'Base Pierce',
@@ -35,7 +35,7 @@ const unitClasses = {
     8: '<abbr title="except Camels">Mounted Units</abbr>',
     9: 'Unused',
     10: 'Unused',
-    11: '<abbr title="except Fish Traps">All Buildings</abbr>',
+    11: 'All Buildings',
     12: 'Unused',
     13: '<abbr title="except Castles and Kreposts">Stone Defense & Harbors</abbr>',
     14: 'Wolves etc.',
@@ -45,7 +45,7 @@ const unitClasses = {
     18: 'Trees',
     19: 'Unique Units',
     20: 'Siege Units',
-    21: '<abbr title="except Fish Traps and Wonders">Standard Buildings</abbr>',
+    21: '<abbr title="All buildings except Wonders">Standard Buildings</abbr>',
     22: 'Walls & Gates',
     23: 'Gunpowder Units',
     24: 'Boars etc.',

--- a/ror/js/techtree.js
+++ b/ror/js/techtree.js
@@ -26,7 +26,7 @@ const getAgeNames = (data) => {
 }
 
 const unitClasses = {
-    0: '<abbr title="unused">Wonders</abbr>',
+    0: 'Wonders',
     1: 'Infantry',
     2: 'Heavy Warships',
     3: 'Base Pierce',
@@ -47,7 +47,7 @@ const unitClasses = {
     18: 'Trees',
     19: 'Unique Units',
     20: 'Siege Units',
-    21: '<abbr title="except Wonders">Standard Buildings</abbr>',
+    21: '<abbr title="All buildings except Wonders">Standard Buildings</abbr>',
     22: 'Walls & Gates',
     23: 'Gunpowder Units',
     24: 'Boars etc.',


### PR DESCRIPTION
Hidden following armor classes from being displayed in UI:
* 0 (Wonders): No unit has attack bonus against them
* 36 (Kings and Heroes): No unit has attack bonus against them in standard play
* 40 (Houses): No unit has attack bonus against them
* 31 (Leitis attack): Obsolete

Updated the definition of armor classes 11 and 21 to include Fish Traps (it has been the case since [update 87863](https://ageofempires.fandom.com/wiki/Update_87863))